### PR TITLE
Init'ed plugins detect setting discrepancies and add them accordingly

### DIFF
--- a/include/config.js
+++ b/include/config.js
@@ -219,6 +219,7 @@ Configuration.getBaseConfig = function(multisite) {
         settings: {
             use_memory: true,
             use_cache: false,
+            autoSync: false,
 
             //The timeout specifies how long in milliseconds a setting will exist
             //in memory before being flushed.  A value of 0 indicates that the


### PR DESCRIPTION
To test this, add a value to a plugin's details.json, restart the server and check your plugin settings in the admin console.
