### PR TITLE
Remove setTransactionName from Request Handler

### DIFF
--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -939,9 +939,6 @@ module.exports = function RequestHandlerModule(pb) {
             }
             if (result) {
 
-                //Do not delete in merge - Kyle - Logan
-                pb.log.setTransactionName(curr.path);
-
                 if(curr.themes[this.siteObj.uid] || curr.themes[GLOBAL_SITE]) {
                     return curr;
                 }


### PR DESCRIPTION
We now label our NewRelic transactions through middleware in our deriveRoute override so we need to remove the request_handler's setTransactionName to prevent overwriting the metric grouping label.
