### PR TITLE
Fix Status Code Err

### DIFF
--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -1296,7 +1296,7 @@ module.exports = function RequestHandlerModule(pb) {
         var self = this;
 
         //infer a response code when not provided
-        if(typeof data.code === 'undefined'){
+        if(!data.code){
             data.code = 200;
         }
 


### PR DESCRIPTION
When data.code === 0 we get an invalid status code RangeError from _http_server.js; the catch for this in request handler originally looked at if data.code was undefined, but a more general check for !data.code would be more comprehensive for preventing bad status codes
