### PR TITLE
Section service should resolve save with the saved object rather than…

### DIFF
--- a/include/service/entities/section_service.js
+++ b/include/service/entities/section_service.js
@@ -729,7 +729,7 @@ module.exports = function SectionServiceModule(pb) {
                     }
                     else if (orphans.length === 0) {
                         //we kept the children so there is nothing to do
-                        return cb(null, true);
+                        return cb(null, data);
                     }
 
                     //ok, now we can delete the orhphans if they exist


### PR DESCRIPTION
… a simple true, so that we can build maps programmatically (need to obtain the uid of the saved object in order to set the parent id of children)

Fixes #

- [ ] Unit tests created and pass
- [ ] JS Docs have been updated

**Description:**



@pencilblue/owners
