### PR TITLE
Style clean up, add description in comment for addSiteToWhere (previo…

### DIFF
--- a/include/service/entities/site_query_service.js
+++ b/include/service/entities/site_query_service.js
@@ -79,16 +79,20 @@ module.exports = function SiteQueryServiceModule(pb) {
     util.inherits(SiteQueryService, DAO);
 
     /**
+     * Given an existing where object to search, add site parameter to the where object so that the returned where searches for object belonging to the site specified by this service's constructor and by the original where object
+     *
+     * If the site is global, also look for objects where site is not set for backwards compatibility
+     *
      * @private
      * @static
-     * @method modifyLoadWhere
+     * @method addSiteToWhere
      * @param {String} site
      * @param {Object} where
      * @return {Object}
      */
-  function modifyLoadWhere(site, where) {
+  function addSiteToWhere(site, where) {
     if (pb.config.multisite.enabled) {
-      where = _.clone(where);
+      where = _.cloneDeep(where);
       if (site === GLOBAL_SITE) {
         var siteDoesNotExist = {}, siteEqualToSpecified = {};
         siteDoesNotExist[SITE_FIELD] = {$exists: false};
@@ -116,7 +120,7 @@ module.exports = function SiteQueryServiceModule(pb) {
       var target = _.clone(options);
 
       target.where = target.where || {};
-      target.where = modifyLoadWhere(site, target.where);
+      target.where = addSiteToWhere(site, target.where);
       return target;
     }
     // else do nothing
@@ -252,7 +256,7 @@ module.exports = function SiteQueryServiceModule(pb) {
    * from persistence.
    */
   SiteQueryService.prototype.delete = function (where, collection, options, cb) {
-      let modifiedWhere = modifyLoadWhere(this.siteUid, where);
+      let modifiedWhere = addSiteToWhere(this.siteUid, where);
       return DAO.prototype.delete.call(this, modifiedWhere, collection, options, cb);
   };
 


### PR DESCRIPTION
…usly modifyLoadWhere).

Use cloneDeep instead of clone, because if the root of the original where object is $or, and the site is global, the function would end up modifying sub-objects of where, which could potentially be undesirable.

Fixes #

- [ ] Unit tests created and pass
- [ ] JS Docs have been updated

**Description:**



@pencilblue/owners
