### PR TITLE
Localization Migration Part II

### DIFF
--- a/plugins/pencilblue/include/routes.js
+++ b/plugins/pencilblue/include/routes.js
@@ -61,36 +61,6 @@ module.exports = function Routes(pb){
         },
         {
             method: 'get',
-            path: '/admin/localization',
-            auth_required: true,
-            access_level: pb.SecurityService.ACCESS_EDITOR,
-            inactive_site_access: true,
-            controller: path.join(pb.config.docRoot, 'plugins', 'pencilblue', 'controllers', 'admin','sites','localizations.js'),
-            content_type: 'text/html'
-        },
-        {
-            method: 'post',
-            path: '/api/localizations/overrides',
-            auth_required: true,
-            access_level: pb.SecurityService.ACCESS_EDITOR,
-            request_body: ['application/json'],
-            inactive_site_access: true,
-            controller: path.join(pb.config.docRoot, 'plugins', 'pencilblue', 'controllers','api', 'localization_controller.js'),
-            content_type: 'text/html',
-            handler:'saveLocales'
-        },
-        {
-            method: 'get',
-            path: '/api/localizations/overrides',
-            auth_required: true,
-            access_level: pb.SecurityService.ACCESS_EDITOR,
-            inactive_site_access: true,
-            controller: path.join(pb.config.docRoot, 'plugins', 'pencilblue', 'controllers','api','localization_controller.js'),
-            content_type: 'application/json',
-            handler:'getLocales'
-        },
-        {
-            method: 'get',
             path: "/admin/login",
             access_level: 0,
             auth_required: false,


### PR DESCRIPTION
 **Description:** 
Removing migrated localization files out of PB core so that they can be added to the pb localization plugin.  This PR only detaches the routes, it does not delete the files.  This is step two in this migration plan.  Step one was to get the new Localization Plugin deployed and that was already completed.