### PR TITLE
default value in registerLocal to empty string so that directives are…

### DIFF
--- a/include/service/entities/template_service.js
+++ b/include/service/entities/template_service.js
@@ -627,7 +627,7 @@ module.exports = function(pb) {
      * @return {Boolean} TRUE when registered successfully, FALSE if not
      */
     TemplateService.prototype.registerLocal = function(flag, callbackFunctionOrValue) {
-        this.localCallbacks[flag] = callbackFunctionOrValue;
+        this.localCallbacks[flag] = callbackFunctionOrValue || '';
         return true;
     };
 


### PR DESCRIPTION
… not accidentally dispalyed on page

Fixes #

- [ ] Unit tests created and pass
- [ ] JS Docs have been updated

**Description:**



@pencilblue/owners
