### PR TITLE
Update Mongo connection options

### DIFF
--- a/include/config.js
+++ b/include/config.js
@@ -153,10 +153,10 @@ Configuration.getBaseConfig = function(multisite) {
             name: 'pencil_blue',
 
             options: {
-                //http://docs.mongodb.org/manual/core/write-concern/
+                autoReconnect: true,
                 w: 1,
                 replicaSet: 'replset-1',
-                readPreference: 'nearest'
+                readPreference: 'secondaryPreferred'
             },
 
             //PB provides the ability to log queries.  This is handy during


### PR DESCRIPTION
Moving readPref to secondaryPreferred so we can leave Primary open for writes; set autoReconnect true so that if the requested node is unavailable we will try again

Reference:
http://mongodb.github.io/node-mongodb-native/2.1/reference/connecting/connection-settings/
