### PR TITLE
CSM-1223

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,6 +46,6 @@
     "respond": "~1.4.2",
     "sprintf": "~1.0.2",
     "textAngular": "^1.5.16",
-    "to-markdown": "~0.0.2"
+    "to-markdown": "0.0.3"
   }
 }


### PR DESCRIPTION
PR for part of [CSM-1223](https://careerbuilder.atlassian.net/browse/CSM-1223).

Fixes a site issue where the bower would resolve to-markdown#~0.0.2 to turndown@0.0.8, which now shares a single repository with to-markdown.
