### PR TITLE
Updated IP Filter rules

### DIFF
--- a/include/http/middleware/auth.js
+++ b/include/http/middleware/auth.js
@@ -12,7 +12,7 @@ module.exports = pb => ({
         };
         var result = pb.RequestHandler.checkRequiresAuth(context);
         if (result.redirect) {
-            throw ErrorUtils.notAuthorized()
+            throw ErrorUtils.notAuthorized();
         }
     },
     authorizationCheck: (req, res) => {
@@ -24,23 +24,23 @@ module.exports = pb => ({
         //check role
         var result = pb.RequestHandler.checkAdminLevel(context);
         if (!result.success) {
-            throw ErrorUtils.forbidden()
+            throw ErrorUtils.forbidden();
         }
 
         //check permissions
         result = pb.RequestHandler.checkPermissions(context);
         if (!result.success && pb.log.isDebug()) {
-            pb.log.debug('AuthCheck: %s', result.message);
+            pb.log.debug(`AuthCheck: ${result.message}`);
         }
         if (!result.success) {
-            throw ErrorUtils.forbidden()
+            throw ErrorUtils.forbidden();
         }
     },
     ipFilterCheck: async (req, res) => {
-        if (pb.config.server.ipFilter.enabled && (req.route.auth_required === true || req.route.path === '/admin/login')) {
-            const authorized = await util.promisify(pb.AdminIPFilter.requestIsAuthorized).call(pb.AdminIPFilter, req)
+        if (pb.config.server.ipFilter.enabled && req.route.path.startsWith('/admin')) {
+            const authorized = await util.promisify(pb.AdminIPFilter.requestIsAuthorized).call(pb.AdminIPFilter, req);
             if (!authorized) {
-                throw ErrorUtils.forbidden()
+                throw ErrorUtils.forbidden();
             }
         }
     }

--- a/test/include/http/middleware/index.spec.js
+++ b/test/include/http/middleware/index.spec.js
@@ -602,20 +602,29 @@ describe('Middleware', function() {
 
         beforeEach(function() {
             req.route = {
-                auth_required: true
-            }
+                auth_required: true,
+                path: '/admin/plugins'
+            };
             sandbox.stub(this.pb.AdminIPFilter, 'requestIsAuthorized').yields(null, false)
         })
 
-        it ('should forbid when enabled and not authorized', (done) => {
+        it ('should forbid when enabled, on admin page, and not authorized', (done) => {
             ipFilterCheck(req, res, (err) => {
                 err.code.should.eql(HttpStatusCodes.FORBIDDEN);
                 done()
             })
         })
 
-        it ('should allow when enabled and authorized', function (done) {
-            this.pb.AdminIPFilter.requestIsAuthorized.yields(null, true)
+        it ('should allow when enabled, on admin page, and authorized', function (done) {
+            this.pb.AdminIPFilter.requestIsAuthorized.yields(null, true);
+            ipFilterCheck(req, res, (err) => {
+                should(err).eql(undefined)
+                done()
+            })
+        })
+        it ('should allow when enabled, not on an admin page, and authorized', function (done) {
+            req.route.path = '/self-service/publish';
+            this.pb.AdminIPFilter.requestIsAuthorized.yields(null, false);
             ipFilterCheck(req, res, (err) => {
                 should(err).eql(undefined)
                 done()


### PR DESCRIPTION
The IP filter now will 403 anything that starts with /admin (as long as it is not in the white list.  This is to say it will check the whitelist for any /admin page.  Not all routes period.)  This is opposed to anything that requires auth.  Also added semicolons to this file

Fixes #

- [ ] Unit tests created and pass
- [ ] JS Docs have been updated

**Description:**



@pencilblue/owners
