### PR TITLE
Prevent path traversal attacks on public content

### DIFF
--- a/plugins/pencilblue/controllers/public.js
+++ b/plugins/pencilblue/controllers/public.js
@@ -57,10 +57,10 @@ module.exports = function PluginPublicContentControllerModule(pb) {
         //mitigates path traversal attacks by using path.normalize to resolve any
         //directory changes (./ and ../) and verifying that the path has one of
         //the prefixes in publicRoutes
-        var normalized = path.normalize(postPluginPath).replace(/^(\.\.[\/\\])+/, '');
+        var normalizedpath = path.normalize(postPluginPath).replace(/^(\.\.[\/\\])+/, '');
         
-        if (publicRoutes.some(prefix => normalize.startsWith(prefix))) {
-            var fullpath = path.join(pluginPublicDir, normalized);
+        if (publicRoutes.some(prefix => normalizedpath.startsWith(prefix))) {
+            var fullpath = path.join(pluginPublicDir, normalizedpath);
             
             //remove qsvars before loading files
             this.reqHandler.servePublicContent(fullpath.split('?')[0]);

--- a/plugins/pencilblue/controllers/public.js
+++ b/plugins/pencilblue/controllers/public.js
@@ -44,7 +44,7 @@ module.exports = function PluginPublicContentControllerModule(pb) {
         var plugin          = this.pathVars.plugin;
         var postPluginPath  = this.pathVars.path;
         var pluginPublicDir = PluginService.getActivePluginPublicDir(plugin);
-        var publicRoutes = ['js/', 'css/', 'fonts/', 'img/', 'localization/', 'favicon.ico', 'docs/', 'dist/'];
+        var publicRoutes = ['js/', 'css/', 'fonts/', 'img/', 'localization/', 'favicon.ico', 'dist/'];
 
         //do check for valid strings otherwise serve 404
         if (!util.isString(postPluginPath) || !util.isString(pluginPublicDir)) {
@@ -65,8 +65,10 @@ module.exports = function PluginPublicContentControllerModule(pb) {
             //remove qsvars before loading files
             this.reqHandler.servePublicContent(fullpath.split('?')[0]);
         } else {
-            this.reqHandler.serve404();
-            return;
+            var forbidden = new Error('Path is not a valid public directory.');
+            forbidden.code = 403;
+
+            return this.serveError(forbidden);
         }
     };
 

--- a/plugins/pencilblue/controllers/public.js
+++ b/plugins/pencilblue/controllers/public.js
@@ -68,7 +68,7 @@ module.exports = function PluginPublicContentControllerModule(pb) {
             var forbidden = new Error('Path is not a valid public directory.');
             forbidden.code = 403;
 
-            return this.serveError(forbidden);
+            return this.reqHandler.serveError(forbidden);
         }
     };
 

--- a/plugins/pencilblue/controllers/public.js
+++ b/plugins/pencilblue/controllers/public.js
@@ -44,6 +44,7 @@ module.exports = function PluginPublicContentControllerModule(pb) {
         var plugin          = this.pathVars.plugin;
         var postPluginPath  = this.pathVars.path;
         var pluginPublicDir = PluginService.getActivePluginPublicDir(plugin);
+        var publicRoutes = ['js/', 'css/', 'fonts/', 'img/', 'localization/', 'favicon.ico', 'docs/', 'dist/'];
 
         //do check for valid strings otherwise serve 404
         if (!util.isString(postPluginPath) || !util.isString(pluginPublicDir)) {
@@ -53,10 +54,20 @@ module.exports = function PluginPublicContentControllerModule(pb) {
         }
 
         //serve up the content
-        var resourcePath = path.join(pluginPublicDir, postPluginPath);
-
-        //remove qsvars before loading files
-        this.reqHandler.servePublicContent(resourcePath.split('?')[0]);
+        //mitigates path traversal attacks by using path.normalize to resolve any
+        //directory changes (./ and ../) and verifying that the path has one of
+        //the prefixes in publicRoutes
+        var normalized = path.normalize(postPluginPath).replace(/^(\.\.[\/\\])+/, '');
+        
+        if (publicRoutes.some(prefix => normalize.startsWith(prefix))) {
+            var fullpath = path.join(pluginPublicDir, normalized);
+            
+            //remove qsvars before loading files
+            this.reqHandler.servePublicContent(fullpath.split('?')[0]);
+        } else {
+            this.reqHandler.serve404();
+            return;
+        }
     };
 
     //exports

--- a/plugins/pencilblue/controllers/public.js
+++ b/plugins/pencilblue/controllers/public.js
@@ -65,6 +65,8 @@ module.exports = function PluginPublicContentControllerModule(pb) {
             //remove qsvars before loading files
             this.reqHandler.servePublicContent(fullpath.split('?')[0]);
         } else {
+            pb.log.error('PluginPublicContentController: Path is not a valid public directory. NORMALIZED_POST_PLUGIN_PATH=[%s] PLUGIN_PUBLIC_DIR=[%s] URL=[%s]', normalizedpath, pluginPublicDir, this.req.url);
+
             var forbidden = new Error('Path is not a valid public directory.');
             forbidden.code = 403;
 


### PR DESCRIPTION
Mitigates path traversal attacks by using path.normalize to resolve any directory changes (`./` and `../`) and verifying that the path has one of the allowed prefixes in publicRoutes.