### PR TITLE
PB 0.9.0 - Localless Routing

### DIFF
--- a/include/http/middleware/localization.js
+++ b/include/http/middleware/localization.js
@@ -45,7 +45,7 @@ module.exports = pb => ({
         let routeLocale = ctx.params.locale || '';
         let localeSources = [routeLocale, ctx.session.locale];
 
-        localeSources.concat(ctx.acceptsLanguages());
+        localeSources = localeSources.concat(ctx.acceptsLanguages());
 
         if (ctx.req.siteObj) {
             opts.supported = Object.keys(ctx.req.siteObj.supportedLocales);

--- a/include/http/middleware/routing.js
+++ b/include/http/middleware/routing.js
@@ -58,7 +58,13 @@ module.exports = pb => ({
         };
 
         let exactMatch = plugins.some(plugin => {
-            descriptor = findDescriptor(plugin[pathname]) || findDescriptor(plugin['/:locale?' + pathname]);
+            descriptor = findDescriptor(plugin[pathname]);
+            if(!descriptor) {
+                descriptor = findDescriptor(plugin['/:locale?' + pathname]);
+                if(descriptor) {
+                    delete ctx.params.locale;
+                }
+            }
             return descriptor;
         });
 


### PR DESCRIPTION
**Description**
Fixes routing that does not have a locale in it to work again

now /test will go to /test and not try and parse test apart to be a locale on /:locale? 