### PR TITLE
DAO Cluster Fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,1 @@
-Fixes #
-
-- [ ] Unit tests created and pass
-- [ ] JS Docs have been updated
-
 **Description:**
-
-
-
-@pencilblue/owners

--- a/controllers/base_controller.js
+++ b/controllers/base_controller.js
@@ -145,6 +145,7 @@ module.exports = function BaseControllerModule(pb) {
          * @type {object}
          */
         this.session = props.session;
+        this.cookies = props.cookies;
 
         /**
          * The deserialized body of the request.  This field is only ever populted if the executing route specifies the

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -677,6 +677,7 @@ module.exports = function RequestHandlerModule(pb) {
                 request: ctx.req,
                 response: ctx.res,
                 session: ctx.session,
+                cookies: ctx.cookies,
                 localization_service: ctx.req.localizationService,
                 path_vars: ctx.params, // TODO: Remove this one
                 pathVars: ctx.params,

--- a/include/http/router.js
+++ b/include/http/router.js
@@ -2,6 +2,8 @@ const Koa = require('koa');
 const Router = require('koa-router');
 const Session = require('../koa/Session')();
 const bodyParser = require('koa-body');
+const Cookies  = require('koa-cookie').default;
+
 
 module.exports = function (pb) {
 
@@ -19,6 +21,7 @@ module.exports = function (pb) {
                 // formidable: { uploadDir: path.join(__dirname, 'tmp') }
             }));
             this.app.use(Session(this.app));
+            this.app.use(Cookies());
         }
 
         static registerRoute(routeDescriptor) {

--- a/include/system/registry/mongo_registration_provider.js
+++ b/include/system/registry/mongo_registration_provider.js
@@ -55,7 +55,7 @@ module.exports = (pb) => {
          * @returns {Promise} Array of statuses
          */
         async getClusterStatus() {
-            return dao.qAsync(pb.config.registry.key, {where: pb.DAO.ANYWHERE});
+            return this.dao.qAsync(pb.config.registry.key, {where: pb.DAO.ANYWHERE});
         }
 
         /**


### PR DESCRIPTION
*Description*
- Fixing critical error that would destroy the mongo DB Topology and send the cluster into a death spiral.  this.dao !== dao.
- Fix cookies so that we have Koa Cookies.  This is now attached to base controller
