### PR TITLE
Handling Unknown routes

### DIFF
--- a/include/http/middleware/errors.js
+++ b/include/http/middleware/errors.js
@@ -1,9 +1,10 @@
 const path = require('path');
+const _ = require('lodash');
 module.exports = pb => {
 
     function initializeLocalization (ctx) {
         let opts = {};
-        let routeLocale = ctx.params.locale || '';
+        let routeLocale = _.get(ctx, 'params.locale', '');
         let localeSources = [];
         const isLocale = /^[a-z]{2}-([A-Z]{2,3}|(419))$/i; // Regex to match a locale en-US for sv-SE etc
         if (isLocale.test(routeLocale)) {

--- a/include/http/router.js
+++ b/include/http/router.js
@@ -128,10 +128,15 @@ module.exports = function (pb) {
 
                 this.app
                     .use(this.router.routes())
-                    .use(this.router.allowedMethods())
-                    .listen(port, () => {
-                        pb.log.info('PencilBlue is ready!');
-                    });
+                    .use(this.router.allowedMethods());
+
+                // Add middleware stack for those routes that are unknown
+                PencilblueRouter._getMiddlewareListForRoutes()
+                    .forEach(middleware => this.app.use(middleware));
+
+                this.app.listen(port, () => {
+                    pb.log.info('PencilBlue is ready!');
+                });
 
                 this.calledOnce = 1;
             }


### PR DESCRIPTION
**Description:**
Fixing handlers for unknown routes to still use the middleware stacks.  /a/b/c/d if that route was not registered by a controller, it would just show the default koa "not found" message instead of the themed error page.  No middleware stacks are called - there is no attempt to redirect away from that unknown route too.  Now there is.  We run through the same middleware stack, but without the route description (it will always fail at this point if a redirect does not happen.) . But it will catch into the error page handler.
