### PR TITLE
Bugfix/tn 966 activate handoff server

### DIFF
--- a/include/http/router.js
+++ b/include/http/router.js
@@ -198,21 +198,23 @@ module.exports = function(pb) {
                 res.end();
             }
             let serverCallback = this.app.callback();
-            try {
-                 var httpServer = http.createServer(onHandoffRequest);
-                 httpServer
-                     .listen(config.http.port, function(err) {
-                         if (!!err) {
-                             pb.log.error('HTTP server FAIL: ', err, (err && err.stack));
-                         }
-                         else {
-                             pb.log.info('PencilBlue Handoff Server is ready!');
-                             pb.log.info(`HTTP  server OK: http://${config.http.domain}:${config.http.port}`);
-                         }
-                     });
-            }
-            catch (ex) {
-                console.error('Failed to start HTTP server\n', ex, (ex && ex.stack));
+            if (process.env.START_HANDOFF_SERVER === '1') {
+                try {
+                    var httpServer = http.createServer(onHandoffRequest);
+                    httpServer
+                        .listen(config.http.port, function(err) {
+                            if (!!err) {
+                                pb.log.error('HTTP server FAIL: ', err, (err && err.stack));
+                            }
+                            else {
+                                pb.log.info('PencilBlue Handoff Server is ready!');
+                                pb.log.info(`HTTP  server OK: http://${config.http.domain}:${config.http.port}`);
+                            }
+                        });
+               }
+               catch (ex) {
+                   console.error('Failed to start HTTP server\n', ex, (ex && ex.stack));
+               }
             }
             try {
                 var httpsServer = https.createServer(config.https.options, serverCallback);

--- a/include/http/router.js
+++ b/include/http/router.js
@@ -168,11 +168,12 @@ module.exports = function(pb) {
         }
         startSSLServerV2 () {
          let config = {
-                domain: pb.config.siteIP,
                 http: {
+                    domain: config.server.ssl.handoff_ip,
                     port: pb.config.server.ssl.handoff_port,
                 },
                 https: {
+                    domain: pb.config.siteIP,
                     port: pb.config.sitePort,
                     options: {
                         key: fs.readFileSync(pb.config.server.ssl.key, 'utf8'),
@@ -198,17 +199,17 @@ module.exports = function(pb) {
             }
             let serverCallback = this.app.callback();
             try {
-//                 var httpServer = http.createServer(onHandoffRequest);
-//                 httpServer
-//                     .listen(config.http.port, function(err) {
-//                         if (!!err) {
-//                             pb.log.error('HTTP server FAIL: ', err, (err && err.stack));
-//                         }
-//                         else {
-                            //pb.log.info('PencilBlue Handoff Server is ready!');
-//                             pb.log.info(`HTTP  server OK: http://${config.domain}:${config.http.port}`);
-//                         }
-//                     });
+                 var httpServer = http.createServer(onHandoffRequest);
+                 httpServer
+                     .listen(config.http.port, function(err) {
+                         if (!!err) {
+                             pb.log.error('HTTP server FAIL: ', err, (err && err.stack));
+                         }
+                         else {
+                             pb.log.info('PencilBlue Handoff Server is ready!');
+                             pb.log.info(`HTTP  server OK: http://${config.http.domain}:${config.http.port}`);
+                         }
+                     });
             }
             catch (ex) {
                 console.error('Failed to start HTTP server\n', ex, (ex && ex.stack));
@@ -222,7 +223,7 @@ module.exports = function(pb) {
                         }
                         else {
                             pb.log.info('PencilBlue with SSL is ready!');
-                            pb.log.info(`HTTPS server OK: http://${config.domain}:${config.https.port}`);
+                            pb.log.info(`HTTPS server OK: http://${config.https.domain}:${config.https.port}`);
                         }
                     });
             }


### PR DESCRIPTION
These changes try to accomplish two goals:
1. Avoid crashing of handoff server in cms-staging environment. I think the issue lied in using the same domain value for both http and https servers
2. Ability to control handoff server activation with a new env variable START_HANDOFF_SERVER

**TEST**
I did not test this locally. Instead, these changes should be tested in cms-staging (staging should be green once START_HANDOFF_SERVER = 1). Please check the changes make sense.