### PR TITLE
Fixing double setting headers and async breakdown

### DIFF
--- a/include/http/middleware/system.js
+++ b/include/http/middleware/system.js
@@ -17,39 +17,39 @@ module.exports = pb => ({
         req.handler.url = url.parse(req.url, true);
         req.handler.hostname = req.headers.host || pb.SiteService.getGlobalSiteContext().hostname;
     },
-    checkPublicRoute: (req, res) => {
-        const pathname = req.handler.url.pathname
+    checkPublicRoute: async (req, res) => {
+        const pathname = req.handler.url.pathname;
         if (publicRoutes.some(prefix => pathname.startsWith(prefix))) {
-            const absolutePath = path.join(pb.config.docRoot, 'public', pathname)
-            req.handler.servePublicContent(absolutePath);
-            req.router.continueAfter('writeResponse')
+            const absolutePath = path.join(pb.config.docRoot, 'public', pathname);
+            await req.handler.servePublicContentAsync(absolutePath);
+            req.router.continueAfter('writeResponse');
         }
     },
-    checkModuleRoute: (req, res) => {
-        const pathname = req.handler.url.pathname
-        const match = modulePattern.exec(pathname)
+    checkModuleRoute: async (req, res) => {
+        const pathname = req.handler.url.pathname;
+        const match = modulePattern.exec(pathname);
         if (match) {
-            let modulePath
+            let modulePath;
             try {
                 modulePath = require.resolve(match[1])
             } catch(_) {
                 throw ErrorUtils.notFound()
             }
-            req.handler.servePublicContent(modulePath)
-            req.router.continueAfter('writeResponse')
+            await req.handler.servePublicContentAsync(modulePath);
+            req.router.continueAfter('writeResponse');
         }
     },
     systemSetupCheck: async (req, res) => {
         const context = {
             route: req.route
         };
-        const result = await util.promisify(req.handler.checkSystemSetup).call(req.handler, context)
+        const result = await util.promisify(req.handler.checkSystemSetup).call(req.handler, context);
         if (!result.success) {
-            return req.router.redirect(result.redirect)
+            return req.router.redirect(result.redirect);
         }
     },
     parseRequestBody: async (req, res) => {
-        let parseBody = util.promisify(req.handler.parseBody).bind(req.handler)
+        let parseBody = util.promisify(req.handler.parseBody).bind(req.handler);
         try {
             req.body = await parseBody(req.route.request_body)
         } catch (err) {
@@ -57,4 +57,4 @@ module.exports = pb => ({
             throw err
         }
     }
-})
+});

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -117,6 +117,8 @@ module.exports = function RequestHandlerModule(pb) {
                     content: content,
                     content_type: mime.lookup(absolutePath)
                 };
+                self.req.controllerResult = data;
+
                 //send response
                 self.writeResponse(data);
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cbtn/pencilblue",
-  "version": "0.8.3-1",
+  "version": "0.8.3-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "website",
         "platform"
     ],
-    "version": "0.8.3-1",
+    "version": "0.8.3-2",
     "repository": {
         "type": "git",
         "url": "https://github.com/careerbuilder/pencilblue.git"


### PR DESCRIPTION
Updating Router to look more like the original 0.8.3 change set.  Removed the old handler function from 0.8.1

In serve public content, we correctly attach the data to controllerResult.

In System for handling of public routes and node modules (Which is deprecated for all but core PB routes/pages) there was an issue where a callback function was not awaiting completion before it was allow to continue the middleware stack.  This was the reason for the error that we saw in the logs - all be it in a very long, round about, and obtuse way.

It would not set the data on the req.controllerResult.  When in Debug mode, that variable is referenced in recordEndTime middleware.  That would error and cause it to fallback into the error handler which would render a new page and call through to the error controller.  Which would go through and reset headers.  By this point, that function that didnt get awaited correctly would have set the headers and sent the request - fulfilling the front end's needs.

In Summary: Correctly sets the controller result int the serving of public routes.  Correctly awaits the completion of serving public content before continuing the middleware stack.  Remove dead code.