### PR TITLE
enabling state param to the login

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/login.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login.js
@@ -19,6 +19,9 @@ module.exports = function LoginSFSSOControllerModule(pb) {
         async salesforceSSO(cb) {
             const salesforceStrategyService = new SalesforceStrategyService();
             const options = await salesforceStrategyService.getSalesforceLoginSettings(this.req);
+            if (this.query.state) {
+                options.url += `&state=${this.query.state}`;
+            }
             request(options).pipe(this.res);
         }
     }

--- a/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
@@ -29,33 +29,47 @@ module.exports = function LoginSalesforceCallbackControllerModule(pb) {
             if (!response) {
                 return this.loginError(cb);
             }
-            let redirectLocation = await this.getRedirectLink(response);
+            let state;
+            if (this.query.state) {
+                try {
+                    state = JSON.parse(this.query.state);
+                } catch (e) {
+                    state = null;
+                    pb.log.warn('Something went wrong during the state parsing: ', e);
+                }
+            }
+            let redirectLocation = await this.getRedirectLink(response, state);
             this.redirect(redirectLocation, cb);
         }
 
         _setupLoginContext() {
             let options = this.body || {};
             options.site = this.site;
-            options.access_level =  pb.SecurityService.ACCESS_USER;
+            options.access_level = pb.SecurityService.ACCESS_USER;
             this.req.session._loginContext = options;
         }
 
-        async getRedirectLink(user) {
+        async getRedirectLink(user, state) {
             let location = '/';
             const siteQueryService = new pb.SiteQueryService();
             const query = {
                 externalUserId: user.external_user_id,
-                object_type : 'jobseeker_profile'
+                object_type: 'jobseeker_profile'
             };
             const hasJobSeekerProfile = await siteQueryService.loadByValuesAsync(query, 'jobseeker_profile');
-            if (this.session.on_login) {
+            if (state && state.redirectURL) {
+                location = state.redirectURL;
+            } else if (this.session.on_login) {
                 location = this.session.on_login;
                 delete this.session.on_login;
             } else if (!hasJobSeekerProfile) {
-               // redirect to create-profile if the user don't have a created jobseeker profile
-               location = `/${this.req.localizationService.language}/profile/create-profile`;
+                // redirect to create-profile if the user don't have a created jobseeker profile
+                location = `/${this.req.localizationService.language}/profile/create-profile`;
             } else {
-                // TODO: Pending route when the user already exists in the jobseeker profile collection
+                location = `/${this.req.localizationService.language}/profile/view`;
+            }
+            if (state) {
+                location += `?state=${JSON.stringify(state)}`;
             }
             return location;
         }

--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -1,15 +1,13 @@
 const request = require('request-promise');
 const Promise = require('bluebird');
-let state, salesforceAPIUrl;
+let salesforceAPIUrl;
 const isSandbox = process.env.USE_SALESFORCE_SANDBOX === 'true';
 const OAUTH_TOKEN_SERVICE = '/services/oauth2/token';
 const OAUTH_AUTHORIZE_SERVICE = '/services/oauth2/authorize';
 if (isSandbox) {
     salesforceAPIUrl = process.env.SALESFORCE_SANDBOX_API_URL;
-    state = 'webServerSandbox';
 } else {
     salesforceAPIUrl = process.env.salesforceAPIUrl;
-    state = 'webServerProd';
 }
 
 let salesforceOAUTHTokenService = salesforceAPIUrl + OAUTH_TOKEN_SERVICE,
@@ -27,7 +25,7 @@ module.exports = function(pb) {
             try {
                 const settings = await this.getSalesforceSettings(req);
                 const options = {
-                    url: `${salesforceOAUTHAuthorizeService}?client_id=${settings.salesforce_client_id}&redirect_uri=https://${req.headers.host}/login/salesforce/callback&response_type=code&state=${state}`,
+                    url: `${salesforceOAUTHAuthorizeService}?client_id=${settings.salesforce_client_id}&redirect_uri=https://${req.headers.host}/login/salesforce/callback&response_type=code`,
                     method: 'POST'
                 };
                 return options;
@@ -59,7 +57,7 @@ module.exports = function(pb) {
                     last_name: salesforceUser.family_name,
                     username: salesforceUser.preferred_username,
                     email: salesforceUser.email,
-                    admin: 0,
+                    admin: 0,// lowest admin level, used to forbid the access to the admin panel
                     object_type: 'user',
                     site: loginContext.site || '',
                     identity_provider: 'salesforce'


### PR DESCRIPTION
This PR contains the code to allow the developer to persist data via the state param (https://auth0.com/docs/protocols/oauth2/oauth-state#csrf-attacks). If you want to redirect to an specified url after the login, you should pass an object (stringified) with a property redirectURL. For example: `login/salesforce?state={"redirectURL":"/en-US/search","test":true}`.

To test these changes, you need to follow the next steps:

1. Run the project in https mode and login via salesforce(follow [this](https://github.com/cbdr/CMSPencilblue/pull/1913) PR's steps to do it)
2. Login via salesforce and add a JSON object stringified. For example: `login/salesforce?state={"test":true}`
3. Once you're logged in, you should see in the redirected route query params the state param with the value you entered. You should be able to access the state param (you should parse it) in the controller via the `this.query.state` property.