### PR TITLE
Add highPriorityToRegister flag to the state params

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
@@ -57,7 +57,9 @@ module.exports = function LoginSalesforceCallbackControllerModule(pb) {
                 object_type: 'jobseeker_profile'
             };
             const hasJobSeekerProfile = await siteQueryService.loadByValuesAsync(query, 'jobseeker_profile');
-            if (state && state.redirectURL) {
+            if (state && state.highPriorityToRegister && !hasJobSeekerProfile) {
+                location = `/${this.req.localizationService.language}/profile/create-profile`;
+            } else if (state && state.redirectURL) {
                 location = state.redirectURL;
             } else if (this.session.on_login) {
                 location = this.session.on_login;


### PR DESCRIPTION
This PR contains the code so we could use the redirectURL param in the create profile view as requested. To use it with the redirectURL, you should pass the highPriorityToRegister property as true in the state params. Example: login/salesforce?state={"redirectURL":"/en-US/search","highPriorityToRegister":true}