### PR TITLE
Adding logout endpoint with the revoke of the salesforce's session.

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/logout.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/logout.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Promise = require('bluebird');
-const Cookies = require('Cookies');
+const Cookies = require('cookies');
 
 module.exports = function LogOutSFSSOControllerModule(pb) {
     /**

--- a/plugins/pencilblue/controllers/actions/salesforce/logout.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/logout.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const Promise = require('bluebird');
+const Cookies = require('Cookies');
+
+module.exports = function LogOutSFSSOControllerModule(pb) {
+    /**
+     * Logs out a user via Salesforce
+     * @class LogOutSFActionControllerModule
+     * @constructor
+     */
+
+    const SalesforceStrategyService = require('../../../services/salesforce/salesforce_strategy_service')(pb);
+    class LogOutSFSSOController extends pb.BaseController {
+        render(cb) {
+            this.sanitizeObject(this.body);
+            this.salesforceLogout(cb);
+        }
+
+        async salesforceLogout(cb) {
+            const salesforceStrategyService = new SalesforceStrategyService();
+            let response = await salesforceStrategyService.logout(this.req);
+            if (response) {
+                try {
+                    await new Promise((resolve, reject) => {
+                        pb.session.end(this.session, (err, result) => {
+                            if (err) {
+                                reject(false);
+                            } else {
+                                //clear the cookie
+                                const cookies = new Cookies(this.req, this.res);
+                                const cookie = pb.SessionHandler.getSessionCookie(this.session);
+                                cookie.expires = new Date();
+                                cookie.overwrite = true;
+                                cookies.set(pb.SessionHandler.COOKIE_NAME, null, cookie);
+                                resolve(true);
+                            }
+                        });
+                    });
+                } catch (e) {
+                    pb.log.error('Something went wrong during the removal of the cookie : ', e);
+                }
+            }
+            this.redirect('/', cb);
+        }
+    }
+
+    return LogOutSFSSOController;
+};

--- a/plugins/pencilblue/include/routes.js
+++ b/plugins/pencilblue/include/routes.js
@@ -69,6 +69,14 @@ module.exports = function Routes(pb){
         },
         {
             method: 'get',
+            path: "/logout/salesforce",
+            auth_required: false,
+            inactive_site_access: true,
+            controller: path.join(pb.config.docRoot, 'plugins', 'pencilblue', 'controllers', 'actions', 'salesforce', 'logout.js'),
+            content_type: 'text/html'
+        },
+        {
+            method: 'get',
             path: "/login/salesforce/callback",
             auth_required: false,
             inactive_site_access: true,


### PR DESCRIPTION
This PR contains the code to allow the developer to logout and prompt the login when it's logout from a jobseeker profile user. 

To test these changes, you need to follow the next steps:

1. Run the project in https mode and login via salesforce(follow [this](https://github.com/cbdr/CMSPencilblue/pull/1913) PR's steps to do it)
2. Create the user, if necessary, and click the /logout/salesforce endpoint to logout.
3. Once you're logged out, enter to the login/salesforce endpoint and you should be able to login again.
