### PR TITLE
Feature/tn-1054-clear local cookie

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/logout.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/logout.js
@@ -21,27 +21,26 @@ module.exports = function LogOutSFSSOControllerModule(pb) {
         async salesforceLogout(cb) {
             const salesforceStrategyService = new SalesforceStrategyService();
             let response = await salesforceStrategyService.logout(this.req);
-            if (response) {
-                try {
-                    await new Promise((resolve, reject) => {
-                        pb.session.end(this.session, (err, result) => {
-                            if (err) {
-                                reject(false);
-                            } else {
-                                //clear the cookie
-                                const cookies = new Cookies(this.req, this.res);
-                                const cookie = pb.SessionHandler.getSessionCookie(this.session);
-                                cookie.expires = new Date();
-                                cookie.overwrite = true;
-                                cookies.set(pb.SessionHandler.COOKIE_NAME, null, cookie);
-                                resolve(true);
-                            }
-                        });
+            try {
+                await new Promise((resolve, reject) => {
+                    pb.session.end(this.session, (err, result) => {
+                        if (err) {
+                            reject(false);
+                        } else {
+                            //clear the cookie
+                            const cookies = new Cookies(this.req, this.res);
+                            const cookie = pb.SessionHandler.getSessionCookie(this.session);
+                            cookie.expires = new Date();
+                            cookie.overwrite = true;
+                            cookies.set(pb.SessionHandler.COOKIE_NAME, null, cookie);
+                            resolve(true);
+                        }
                     });
-                } catch (e) {
-                    pb.log.error('Something went wrong during the removal of the cookie : ', e);
-                }
+                });
+            } catch (e) {
+                pb.log.error('Something went wrong during the removal of the cookie : ', e);
             }
+
             if (response && response.enableCustomLogout && response.url) {
                 request({
                     url: response.url,


### PR DESCRIPTION
# Why:

We experienced logout failed in preprod sites yesterday. The failing of auth of SF lead to the situation, we were not clearing cookie in our app.

After discussion with Bradley, he agreed that even logout failed at SF side, we still need to clear out app cookie.

# How to reproduce:

1. Go to https://aerotek-cms-preprod.cbtalentnetwork.com/search, login in 
2. Go to profile page, make sure you stayed https://aerotek-cms-preprod.cbtalentnetwork.com/en-US/profile/view, then log out
3. after you been redirect to another page, click on go back. You will be redirected to profile/view page. Still logged in.

# What did in this change:
In code, SF logout auth failed causes response = null, and the clear cookie is within the bound of the condition response!== null. 

I just removed the condition check. In this case, we always clear our side cookie when /logout/salesforce is called.

# What need to follow:

release a new version of pencilblue. Use the updated version number in CMSPencilblue repo.

# Note: the failed one unit test is the same in cms-dep branch. Not a new issue. 