### PR TITLE
TN-1084 Register option for SF

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/register.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/register.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const request = require('request-promise');
+
+module.exports = function RegisterSFControllerModule(pb) {
+    /**
+     * Registers a user via Salesforce
+     * @class RegisterSFControllerModule
+     * @constructor
+     */
+
+    const SalesforceStrategyService = require('../../../services/salesforce/salesforce_strategy_service')(pb);
+    class RegisterSFController extends pb.BaseController {
+        render(cb) {
+            this.sanitizeObject(this.body);
+            this.salesforceRegister(cb);
+        }
+
+        async salesforceRegister(cb) {
+            const salesforceStrategyService = new SalesforceStrategyService();
+            let response = await salesforceStrategyService.register(this.req);
+
+            if (response && response.enableCustomRegister && response.url) {
+                this.redirect(response.url, cb);
+            } else {
+                this.redirect('/login/salesforce', cb);
+            }
+        }
+    }
+
+    return RegisterSFController;
+};

--- a/plugins/pencilblue/include/routes.js
+++ b/plugins/pencilblue/include/routes.js
@@ -69,6 +69,14 @@ module.exports = function Routes(pb){
         },
         {
             method: 'get',
+            path: "/register/salesforce",
+            auth_required: false,
+            inactive_site_access: true,
+            controller: path.join(pb.config.docRoot, 'plugins', 'pencilblue', 'controllers', 'actions', 'salesforce', 'register.js'),
+            content_type: 'text/html'
+        },
+        {
+            method: 'get',
             path: "/logout/salesforce",
             auth_required: false,
             inactive_site_access: true,

--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -43,6 +43,19 @@ module.exports = function(pb) {
             }
         }
 
+        async register(req) {
+            try {
+                const settings = await this.getSalesforceSettings(req);
+                return {
+                    enableCustomRegister: settings.enable_custom_register_url,
+                    url: settings.custom_register_url
+                };
+            } catch (e) {
+                pb.log.error('Something went wrong during salesforce register: ', e);
+                return null;
+            }
+        }
+
         async getSalesforceLoginSettings(req) {
             try {
                 const settings = await this.getSalesforceSettings(req);


### PR DESCRIPTION
The changes cover the acceptance criteria for the associated card:
1. When updating the tn_auth plugin settings, there will also be a custom register URL entry field.
2. When updating the tn_auth plugin settings, there will also be switch to use the custom register URL.
3. When selecting to use the custom URL, the URL that is entered will be called when clicking on the Register button.

**TEST**
0. Point CMSPencilblue to your local pencilblue repo. Install, build, run
1. Register the auth panel by placing `^auth_control_panel^` somewhere in the theme content
3. Go to your local site and click Register. You should be redirected to SF login page
4. Go to your local site admin > tn_auth settings and set: "Enable Custom Register URL"=Yes, "Custom Register URL"="https://load-allegisconnected.cs85.force.com/aerotekjobseeker/js_registration" (You can use whatever URL you want, this is an example), and save
5. Go to your local site and click Register. You should be redirected to the URL defined in #4