### PR TITLE
TN-1084 allow use of the login process to obtain an URL to be used fo…

### DIFF
--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -48,7 +48,10 @@ module.exports = function(pb) {
                 const settings = await this.getSalesforceSettings(req);
                 return {
                     enableCustomRegister: settings.enable_custom_register_url,
-                    url: settings.custom_register_url
+                    url: settings.custom_register_url,
+                    hackUserAuthFlow: settings.force_auth_process_for_register,
+                    toReplace: settings.register_string_to_replace,
+                    replacement: settings.register_replacement_string
                 };
             } catch (e) {
                 pb.log.error('Something went wrong during salesforce register: ', e);


### PR DESCRIPTION
These changes provide an option to make use of the auth user flow to retrieve the SF login URL and use it for Register, with whatever features this generated URL may have for the registration process.

**TEST**
0. Point CMSPencilblue to your local pencilblue repo. Install, build, run
1. Assuming you have the settings for Aerotek, go to tn_auth plugin options for your local site. Set "Make use of login process to obtain register URL (overrides 'Custom Register URL')" to Yes. Set "String to replace in forced register URL (works with 'Make use of login process...')"="js_login" and "Replacement in forced register URL (works with 'Make use of login process...')"="js_registration" (without quotes). Save changes and logout.
2. Go to /register/salesforce. Yo should be sent to the register page.
3. Complete registration. Depending on the case you will be redirected to the SF login page or the CMS site. If the login page is displayed, log in and follow any other steps. At the end you should be redirected to the CMS site