### PR TITLE
reverse-proxy-work callback aware of prefix and/or origin domain (reverse proxy domain)

### DIFF
--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -63,7 +63,7 @@ module.exports = function(pb) {
             try {
                 const settings = await this.getSalesforceSettings(req);
                 const options = {
-                    url: `${salesforceOAUTHAuthorizeService}?client_id=${settings.salesforce_client_id}&redirect_uri=https://${req.headers.host}/login/salesforce/callback&response_type=code&prompt=login`,
+                    url: `${salesforceOAUTHAuthorizeService}?client_id=${settings.salesforce_client_id}&redirect_uri=${this.getCallBackURL(req)}&response_type=code&prompt=login`,
                     method: 'POST'
                 };
                 return options;
@@ -78,7 +78,7 @@ module.exports = function(pb) {
                 const loginContext = req.session._loginContext || {};
                 const settings = await this.getSalesforceSettings(req);
                 const options = {
-                    url: `${salesforceOAUTHTokenService}?client_id=${settings.salesforce_client_id}&redirect_uri=https://${req.headers.host}/login/salesforce/callback&grant_type=authorization_code&code=${code}&client_secret=${settings.salesforce_client_secret}`,
+                    url: `${salesforceOAUTHTokenService}?client_id=${settings.salesforce_client_id}&redirect_uri=${this.getCallBackURL(req)}&grant_type=authorization_code&code=${code}&client_secret=${settings.salesforce_client_secret}`,
                     method: 'POST',
                     json: true
                 };
@@ -133,6 +133,26 @@ module.exports = function(pb) {
                 salesforceAPIUrl = settings.app_url;
             }
             return settings;
+        }
+
+        getCallBackURL(req) {
+            let baseURL;
+
+            if (req.siteObj.origin) {
+                // just to be safe, but siteObj.origin should not contain a protocol
+                if (!req.siteObj.origin.includes('http://') && !req.siteObj.origin.includes('https://')) {
+                    baseURL = `https://${req.siteObj.origin}`;
+                } else {
+                    baseURL = `${req.siteObj.origin}`;
+                }
+            } else {
+                baseURL = `https://${req.headers.host}`;
+            }
+            if (req.siteObj.prefix) {
+                baseURL += `/${req.siteObj.prefix}`;
+            }
+
+            return `${baseURL}/login/salesforce/callback`;
         }
     };
 


### PR DESCRIPTION
TEST
There is no direct test of this, until we hit preprod. But you can check how the callback URL changes depending on the settings: add a console.log for options variable in plugins\pencilblue\controllers\actions\salesforce\login.js, just before line 25

1. Allow CMSPenciblue to read your penciblue repo, as usual
2. Define an origin and prefix (base route) for a local site in the Site settings, log off
3. Go to /login/salesforce. You should see this output in console (will change depending on your settings:
```
options:  {
	url: 'https://load-allegisconnected.cs85.force.com/aerotekjobseeker/services/oauth2/authorize?client_id=3MVG9llQY5kM9T6fDHMygBNC37wtu50yEhQ6FyiFZazEu.A3y9TWT73dEvgDecm7qwp4a5R52vwGITxBPwwcw&redirect_uri=https://somedomain/it-jobs/login/salesforce/callback&response_type=code&prompt=login',
	method: 'POST'
}  
```
**_SF login could break since this callback URL may not be authorized yet by SF_**
4. Go again to your settings and remove origin value. Log off
5. Go to /login/salesforce. You should see this output in console (will change depending on your settings:
```
options:  {
	url: 'https://load-allegisconnected.cs85.force.com/aerotekjobseeker/services/oauth2/authorize?client_id=3MVG9llQY5kM9T6fDHMygBNC37wtu50yEhQ6FyiFZazEu.A3y9TWT73dEvgDecm7qwp4a5R52vwGITxBPwwcw&redirect_uri=https://premium.lvh.me:8080/it-jobs/login/salesforce/callback&response_type=code&prompt=login',
	method: 'POST'
}
```
**_SF login could break since this callback URL may not be authorized yet by SF_**
6. Go again to your settings and remove base route/prefix value. Log off
7. Go to /login/salesforce. You should see this output in console (will change depending on your settings:
```
options:  {
	url: 'https://load-allegisconnected.cs85.force.com/aerotekjobseeker/services/oauth2/authorize?client_id=3MVG9llQY5kM9T6fDHMygBNC37wtu50yEhQ6FyiFZazEu.A3y9TWT73dEvgDecm7qwp4a5R52vwGITxBPwwcw&redirect_uri=https://premium.lvh.me:8080/login/salesforce/callback&response_type=code&prompt=login',
	method: 'POST'
}
```
8. SF login should work locally, complete it. It should keep working as before the changes
