### PR TITLE
fix image in CSS prefix issue and ng-src prefix issue

### DIFF
--- a/include/http/middleware/controller.js
+++ b/include/http/middleware/controller.js
@@ -86,7 +86,7 @@ module.exports = pb => ({
 
                             jQuery.fn.extend({
                                 attr: function( name, value ) {
-                                    if (name === 'href' && /^\\//.test(value) && !/^\\/${prefix}/.test(value)) {
+                                    if ((name === 'href' || name === 'src') && /^\\//.test(value) && !/^\\/${prefix}/.test(value)) {
                                         value = '/${prefix}' + value;
                                     }
 

--- a/include/http/middleware/controller.js
+++ b/include/http/middleware/controller.js
@@ -71,9 +71,11 @@ module.exports = pb => ({
             // Inject the global value redirectHref in window
             content = content.replace(/<body[^>]*>/, function (match) {
                 return `${match}<script>
+                            const reg = new RegExp('^\/(?!${prefix})');
+
                             Object.defineProperty(window, 'redirectHref', {
                                 set(val) {
-                                    if (/^\\//.test(val)) {
+                                    if (reg.test(val)) {
                                         this.location.href = '/${prefix}' + val;
                                     } else {
                                         this.location.href = val;
@@ -86,7 +88,7 @@ module.exports = pb => ({
 
                             jQuery.fn.extend({
                                 attr: function( name, value ) {
-                                    if ((name === 'href' || name === 'src') && /^\\//.test(value) && !/^\\/${prefix}/.test(value)) {
+                                    if ((name === 'href' || name === 'src') && reg.test(value)) {
                                         value = '/${prefix}' + value;
                                     }
 

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -367,7 +367,7 @@ module.exports = function RequestHandlerModule(pb) {
                         content = new Buffer(content).toString();
                     }
 
-                    content = content.replace(/(url\(['"])(\/[^'"\)]*['"]\s*\))/g, function (match, p1, p2) {
+                    content = content.replace(/(url\(['"]?)(\/[^'"\)]*['"]?\s*\))/g, function (match, p1, p2) {
                         if (p2.indexOf(prefix) === 0 || p2.indexOf(prefix) === 1) {
                             return match;
                         } else {

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -360,6 +360,16 @@ module.exports = function RequestHandlerModule(pb) {
                     content = content.replace(/\/public\/premium\/?/g, function (match) {
                         return `/${prefix}${match}`;
                     });
+
+                    // Handle the tags in JavaScirpt.
+                    content = content.replace(/(\<(?:a|link|script|img|image)(?:[^\>]|\r|\n)*\s(?:ng-href|href|src)\s*=\s*['"]\/)([^\/][^'"\>]*)(['"])/mg, function (match, p1, p2, p3) {
+                        if (p2.indexOf(prefix) !== 0 && p2.indexOf(prefix) !== 1) {
+                            return `${p1}${prefix}/${p2}${p3}`;
+                        } else {
+                            return `${p1}${p2}${p3}`;
+                        }
+                    });
+
                 }
 
                 if (prefix && contentType === 'text/css') {


### PR DESCRIPTION
- If the URL has not been wrapped in ' or " in css files, the prefix will not be added successfully.
![image](https://user-images.githubusercontent.com/5660841/56876835-b9f76d00-6a7c-11e9-9c18-1bb448015c96.png)
**How to verify?**
Update the CSS [in Admin](http://premium.lvh.me:8080/admin/plugins/premium/settings), and then to check the [CSS file](http://premium.lvh.me:8080/jobs/public/premium/css/premium_custom_styles.css).

- If the HTML is load in JavaScript, the HTML tags will not be add the prefix.
![image](https://user-images.githubusercontent.com/5660841/56876886-0f337e80-6a7d-11e9-9939-c041e81f6aa5.png)
**How to Verify?**
You will see the Image issue when you open [Profile Edit Page](http://10.63.88.62:8000/jobs/en-US/profile/view). 

- `ng-src` will not be add the prefix successfully.
![image](https://user-images.githubusercontent.com/5660841/56876930-3427f180-6a7d-11e9-9138-c43a4633cd9f.png)
**How to Verify?**
This issue happens on Apply Finish Page. 