### PR TITLE
TN-1163 avoid use of startsWith function over undefined value

### DIFF
--- a/include/http/middleware/system.js
+++ b/include/http/middleware/system.js
@@ -32,7 +32,7 @@ module.exports = pb => ({
         //     pathname = pathname.replace(new RegExp(`^\/${sitePrefix}`), '');
         // }
 
-        if (publicRoutes.some(prefix => pathname.startsWith(prefix))) {
+        if (pathname && publicRoutes.some(prefix => pathname.startsWith(prefix))) {
             const absolutePath = path.join(pb.config.docRoot, 'public', pathname);
             await req.handler.servePublicContentAsync(absolutePath);
             req.router.continueAfter('writeResponse');


### PR DESCRIPTION
Really quick check for undefinition. I came across this while testing locally, but I am not sure on what are the exact steps to reproduce the issue.