### PR TITLE
TN-1167 implementation of new setting to control prefix in login callback url

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
@@ -41,7 +41,7 @@ module.exports = function LoginSalesforceCallbackControllerModule(pb) {
             if (response.updateEmail) {
                 await this.updateEmail(response.user);
             }
-            let redirectLocation = await this.getRedirectLink(response.user, state);
+            let redirectLocation = await this.getRedirectLink(response.user, state, salesforceStrategyService);
             this.redirect(redirectLocation, cb);
         }
 
@@ -72,7 +72,7 @@ module.exports = function LoginSalesforceCallbackControllerModule(pb) {
             this.req.session._loginContext = options;
         }
 
-        async getRedirectLink(user, state) {
+        async getRedirectLink(user, state, salesforceStrategyService) {
             let location = '/';
             const siteQueryService = new pb.SiteQueryService();
             const query = {
@@ -96,6 +96,13 @@ module.exports = function LoginSalesforceCallbackControllerModule(pb) {
             if (state) {
                 location += `?state=${JSON.stringify(state)}`;
             }
+
+            const options = await salesforceStrategyService.getSalesforceCallbackSettings(this.req);
+
+            if (options.addPrefix && location.indexOf(options.prefix) !== 1) {
+                location = `/${options.prefix}${location}`;
+            }
+
             return location;
         }
     }

--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -59,6 +59,19 @@ module.exports = function(pb) {
             }
         }
 
+        async getSalesforceCallbackSettings(req) {
+            const settings = await this.getSalesforceSettings(req);
+            const options = {
+                addPrefix: req.siteObj && req.siteObj.prefix && settings.use_prefix_cb_redir
+            }
+
+            if (options.addPrefix) {
+                options.prefix = req.siteObj.prefix;
+            }
+
+            return options;
+        }
+
         async getSalesforceLoginSettings(req) {
             try {
                 const settings = await this.getSalesforceSettings(req);


### PR DESCRIPTION
For reverse proxies other than TEKSystems one, it seems the login process redirection (at the end of it) is not including the prefix defined for the site. These changes aim to control this case.

**TEST**
You need these changes and also these PR changes for CMSPenciblue

1. Activate the new setting "Use prefix in callback redirection"
2. Proceed with the login process. It should work
3. Deactivate the new setting and try again. Login process should keep working.

I hope this setting to be temporary. Right now, I don't want to risk to break TEKSystems. My plan is to wait for these changes to be in preprod and validate this. If these changes don't break the mentioned site and fix the issue for the rest of rev proxies, I will then perform a refactor to remove this setting.
