### PR TITLE
Close session on SF logout

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/logout.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/logout.js
@@ -27,6 +27,8 @@ module.exports = function LogOutSFSSOControllerModule(pb) {
                         if (err) {
                             reject(false);
                         } else {
+                            //close the session (destroys all, including session uid)
+                            pb.session.close(this.session, () => {});
                             //clear the cookie
                             const cookies = new Cookies(this.req, this.res);
                             const cookie = pb.SessionHandler.getSessionCookie(this.session);
@@ -38,7 +40,7 @@ module.exports = function LogOutSFSSOControllerModule(pb) {
                     });
                 });
             } catch (e) {
-                pb.log.error('Something went wrong during the removal of the cookie : ', e);
+                pb.log.error('Something went wrong during session closing and the removal of the cookie : ', e);
             }
 
             if (response && response.enableCustomLogout && response.url) {


### PR DESCRIPTION
I noticed we have a close() function in include\session\session.js that can work with the outcome of calling session.end().

With this addition all the work related to destroy the session is done in the logout context.

**TEST**
You need to activate "Enable Custom Logout" in tn_auth. Get the details from TEKSystems preprod. You also need the login and register buttons visible. Use incognito browser mode.
1. Log in via SF. You should see Profile and Logout buttons
2. Log out. SF page shows an error
3. Get back manually to the site (by typing the URL). You should see Login and Register button.
4. **_Repeat steps 1 to 3 without these changes_**. You should check that step number 3 fails (You will see Profile and Logout buttons instead)

**_Note_**: if you can't see the SF error, modify your host file so the custom logout URL points to a local IP. You need to achieve a state where when you click the logout button you see anything different to the expected SF functionality.