### PR TITLE
TN-1165 redir to custom logout url and code cleanup

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/logout.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/logout.js
@@ -44,11 +44,14 @@ module.exports = function LogOutSFSSOControllerModule(pb) {
             }
 
             if (response && response.enableCustomLogout && response.url) {
-                request({
-                    url: response.url,
-                    method: 'GET'
-                }).pipe(this.res);
-
+                if (response.serverSideCustomLogoutRequest) {
+                    request({
+                        url: response.url,
+                        method: 'GET'
+                    }).pipe(this.res);
+                } else {
+                    this.redirect(response.url, cb);
+                }
             } else {
                 this.redirect('/', cb);
             }

--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -34,6 +34,7 @@ module.exports = function(pb) {
                 };
                 await request(options);
                 return {
+                    serverSideCustomLogoutRequest: settings.server_custom_logout_request,
                     enableCustomLogout: settings.enable_custom_logout_url,
                     url: settings.custom_logout_url
                 };

--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -61,9 +61,8 @@ module.exports = function(pb) {
         }
 
         async getSalesforceCallbackSettings(req) {
-            const settings = await this.getSalesforceSettings(req);
             const options = {
-                addPrefix: req.siteObj && req.siteObj.prefix && settings.use_prefix_cb_redir
+                addPrefix: req.siteObj && req.siteObj.prefix
             }
 
             if (options.addPrefix) {


### PR DESCRIPTION
This work is a collaboration between @shenghua-cb  and @JoseDomingoMoraNunezCB 

We perform a request in the server side to call the custom logout URL. The problem with this seems to be that the context provided to SF by the server is not the same that the one present in the browser, where the user followed the SF login process. This could lead SF to not properly log out the user.

I have added a setting that I hope to be temporary, to activate a redirection instead a server request. The purpose of this setting is to provide backwards compatibility for the time being, while we move forward to the definitive solution.

**TEST**
1. You can try and reproduce the issue, by logging in, then logging out (via incognito window). You should see a SF error page after clicking the login link/button.
2. Go to the site's tn_auth settings, and set "Custom logout URL should be called by the server (No = should be a redirection) " to No.
3. Repeat step 1. Yo should be able to see the login page once you logout.

Note: You won't be redirected back to our site. It seems this is something Allegis should configure. Take this PR description as reference (step number 5) https://github.com/cbdr/CMSPencilblue/pull/1989

As a minor change, I'm removing a setting that is no longer required, related to adding the prefix to the callback URL redirection (adding the prefix is needed, the setting is not)