### PR TITLE
TN-1106 sanitize state redirect url

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/login.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login.js
@@ -20,10 +20,15 @@ module.exports = function LoginSFSSOControllerModule(pb) {
             const salesforceStrategyService = new SalesforceStrategyService();
             const options = await salesforceStrategyService.getSalesforceLoginSettings(this.req);
             if (this.query.state) {
-                if (this.query.state.redirectURL) {
-                    this.query.state.redirectURL = encodeURIComponent(this.query.state.redirectURL);
+                try {
+                    let state = JSON.parse(this.query.state);
+                    if (state.redirectURL) {
+                        state.redirectURL = encodeURIComponent(state.redirectURL);
+                    }
+                    options.url += `&state=${JSON.stringify(state)}`;
+                } catch (e) {
+                    pb.log.warn('Something went wrong during the state parsing: ', e);
                 }
-                options.url += `&state=${this.query.state}`;
             }
 
             request(options)

--- a/plugins/pencilblue/controllers/actions/salesforce/login.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login.js
@@ -20,6 +20,9 @@ module.exports = function LoginSFSSOControllerModule(pb) {
             const salesforceStrategyService = new SalesforceStrategyService();
             const options = await salesforceStrategyService.getSalesforceLoginSettings(this.req);
             if (this.query.state) {
+                if (this.query.state.redirectURL) {
+                    this.query.state.redirectURL = encodeURIComponent(this.query.state.redirectURL);
+                }
                 options.url += `&state=${this.query.state}`;
             }
 

--- a/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
@@ -94,6 +94,9 @@ module.exports = function LoginSalesforceCallbackControllerModule(pb) {
                 location = `/${this.req.localizationService.language}/profile/view`;
             }
             if (state) {
+                if (state.redirectURL) {
+                    state.redirectURL = encodeURIComponent(state.redirectURL);
+                }
                 location += `?state=${JSON.stringify(state)}`;
             }
 

--- a/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login_callback.js
@@ -97,7 +97,8 @@ module.exports = function LoginSalesforceCallbackControllerModule(pb) {
                 if (state.redirectURL) {
                     state.redirectURL = encodeURIComponent(state.redirectURL);
                 }
-                location += `?state=${JSON.stringify(state)}`;
+                let token = location.includes('?') ? '&' : '?';
+                location += `${token}state=${JSON.stringify(state)}`;
             }
 
             const options = await salesforceStrategyService.getSalesforceCallbackSettings(this.req);


### PR DESCRIPTION
These corrections allow to use a more "complex" redirect URL as part of the SF login and register processes. For example, an URL containing ampersands currently breaks the functionality.

**TEST**
You need to pull the changes from https://github.com/cbdr/CMSPencilblue/tree/bugfix/TN-1106-redirect-logged-user-to-apply-start

**1) Log in case**
1. Go to tn_profile settings and set "Enforce user authentication before apply" to Yes
2. Go incognito. Go to a JDP and click Apply. You should be redirected to the SF login process
3. Complete the SF login process with **existent** credentials. You should be finally redirected to the actual Apply page and not the JDP

**2) Register case**
1. Go to tn_profile settings and set "Enforce user authentication before apply" to Yes
2. Go incognito. Go to a JDP and click Apply. You should be redirected to the SF login process
3. Complete the SF login process with **new** credentials. You should be redirected to the create profile page,
4. Complete the create Profile section. You should be redirected to the actual Apply page and not the JDP

**3) CASL case**
1. Go to tn_profile settings and set "Enforce user authentication before apply" to Yes
2. Go to tn_profile settings and set "Show CASL Questions For All The Users " to Yes
3. Go to tn_profile settings and set "TNDID " to a different OpCo
4. Go incognito. Go to a JDP and click Apply. You should be redirected to the SF login process
5. Complete the SF login process with **existent** credentials. You should be redirected to a page where you need to fill some checkboxes before being redirected to the actual Apply page

**Note**: affected unit and selenium tests in https://github.com/cbdr/CMSPencilblue/tree/bugfix/TN-1106-redirect-logged-user-to-apply-start must pass
