### PR TITLE
AO-3825: Logic for setting "set-cookies" to secure

### DIFF
--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -356,9 +356,10 @@ module.exports = function RequestHandlerModule(pb) {
                 }
 
                 this.resp.setHeader('content-type', contentType);
-                const enabledSecureCookie = this.req && this.req.siteObj && this.req.siteObj.enabledSecureCookie;
+                let enabledSecureCookie = this.req && this.req.siteObj && this.req.siteObj.enabledSecureCookie;
+                enabledSecureCookie = (enabledSecureCookie == undefined) ? true : enabledSecureCookie;
                 const cookies = this.resp.getHeader('set-cookie');
-                if (enabledSecureCookie && cookies) {
+                if (setDefaultSecureCookie && cookies) {
                     cookies.forEach((cookie, index) => {
                         if (!/\bsecure\b/g.test(cookie)) {
                             cookies[index] = `${cookie}; Secure`;

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -356,6 +356,20 @@ module.exports = function RequestHandlerModule(pb) {
                 }
 
                 this.resp.setHeader('content-type', contentType);
+
+                const secureCookies = this.req && this.req.siteObj && this.req.siteObj.secureCookies;
+                if (secureCookies) {
+                    const cookies = this.resp.getHeader('set-cookie');
+                    (cookies || []).forEach((cookie, index) => {
+                        if (!/\bsecure\b/g.test(cookie)) {
+                            cookies[index] = `${cookie}; Secure`;
+                        }
+                    });
+                    if (cookies) {
+                        this.resp.setHeader('set-cookie', cookies);
+                    }
+                }
+
                 this.resp.writeHead(data.code);
                 //write content
                 var content = data.content;

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -356,10 +356,9 @@ module.exports = function RequestHandlerModule(pb) {
                 }
 
                 this.resp.setHeader('content-type', contentType);
-                let enabledSecureCookie = this.req && this.req.siteObj && this.req.siteObj.enabledSecureCookie;
-                enabledSecureCookie = (enabledSecureCookie == undefined) ? true : enabledSecureCookie;
+                let disableSecureCookie = this.req && this.req.siteObj && this.req.siteObj.disableSecureCookie;
                 const cookies = this.resp.getHeader('set-cookie');
-                if (enabledSecureCookie && cookies) {
+                if (!disableSecureCookie && cookies) {
                     cookies.forEach((cookie, index) => {
                         if (!/\bsecure\b/g.test(cookie)) {
                             cookies[index] = `${cookie}; Secure`;

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -356,20 +356,16 @@ module.exports = function RequestHandlerModule(pb) {
                 }
 
                 this.resp.setHeader('content-type', contentType);
-
-                const secureCookies = this.req && this.req.siteObj && this.req.siteObj.secureCookies;
-                if (secureCookies) {
-                    const cookies = this.resp.getHeader('set-cookie');
-                    (cookies || []).forEach((cookie, index) => {
+                const enabledSecureCookie = this.req && this.req.siteObj && this.req.siteObj.enabledSecureCookie;
+                const cookies = this.resp.getHeader('set-cookie');
+                if (secureCookies && cookies) {
+                    cookies.forEach((cookie, index) => {
                         if (!/\bsecure\b/g.test(cookie)) {
                             cookies[index] = `${cookie}; Secure`;
                         }
                     });
-                    if (cookies) {
-                        this.resp.setHeader('set-cookie', cookies);
-                    }
+                    this.resp.setHeader('set-cookie', cookies);
                 }
-
                 this.resp.writeHead(data.code);
                 //write content
                 var content = data.content;

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -359,7 +359,7 @@ module.exports = function RequestHandlerModule(pb) {
                 let enabledSecureCookie = this.req && this.req.siteObj && this.req.siteObj.enabledSecureCookie;
                 enabledSecureCookie = (enabledSecureCookie == undefined) ? true : enabledSecureCookie;
                 const cookies = this.resp.getHeader('set-cookie');
-                if (setDefaultSecureCookie && cookies) {
+                if (enabledSecureCookie && cookies) {
                     cookies.forEach((cookie, index) => {
                         if (!/\bsecure\b/g.test(cookie)) {
                             cookies[index] = `${cookie}; Secure`;

--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -358,7 +358,7 @@ module.exports = function RequestHandlerModule(pb) {
                 this.resp.setHeader('content-type', contentType);
                 const enabledSecureCookie = this.req && this.req.siteObj && this.req.siteObj.enabledSecureCookie;
                 const cookies = this.resp.getHeader('set-cookie');
-                if (secureCookies && cookies) {
+                if (enabledSecureCookie && cookies) {
                     cookies.forEach((cookie, index) => {
                         if (!/\bsecure\b/g.test(cookie)) {
                             cookies[index] = `${cookie}; Secure`;

--- a/plugins/pencilblue/templates/admin/sites/site_form.html
+++ b/plugins/pencilblue/templates/admin/sites/site_form.html
@@ -22,6 +22,13 @@
                         <label>Base route</label>
                         <input type="text" name="prefix" class="form-control" ng-model="prefix">
                     </div>
+                    <div class="form-group"> 
+                        <label>Secure Cookies</label> 
+                        <div class="btn-group"> 
+                            <button type="button" id="enable-custom-redirect" class="btn btn-default" ng-class="{'active': secureCookies}" ng-click="secureCookies = true">^loc_YES^</button> 
+                            <button type="button" id="disable-custom-redirect" class="btn btn-default" ng-class="{'active': !secureCookies}" ng-click="secureCookies = false">^loc_NO^</button> 
+                        </div> 
+                     </div>
                     <div class="form-group" ng-class="{'has-error': !isFieldValid(siteForm.origin)}">
                         <label>Site origin</label>
                         <input type="text" name="origin" class="form-control" ng-model="origin">

--- a/plugins/pencilblue/templates/admin/sites/site_form.html
+++ b/plugins/pencilblue/templates/admin/sites/site_form.html
@@ -22,13 +22,6 @@
                         <label>Base route</label>
                         <input type="text" name="prefix" class="form-control" ng-model="prefix">
                     </div>
-                    <div class="form-group"> 
-                        <label>Secure Cookies</label> 
-                        <div class="btn-group"> 
-                            <button type="button" id="enable-custom-redirect" class="btn btn-default" ng-class="{'active': secureCookies}" ng-click="secureCookies = true">^loc_YES^</button> 
-                            <button type="button" id="disable-custom-redirect" class="btn btn-default" ng-class="{'active': !secureCookies}" ng-click="secureCookies = false">^loc_NO^</button> 
-                        </div> 
-                     </div>
                     <div class="form-group" ng-class="{'has-error': !isFieldValid(siteForm.origin)}">
                         <label>Site origin</label>
                         <input type="text" name="origin" class="form-control" ng-model="origin">

--- a/plugins/pencilblue/templates/angular/admin/sites/site_form.html
+++ b/plugins/pencilblue/templates/angular/admin/sites/site_form.html
@@ -24,6 +24,7 @@
                                 selectedLocales: $scope.selectedLocales,
                                 defaultLocale: $scope.defaultLocale,
                                 useCustomRedirect: $scope.useCustomRedirect || true,
+                                enabledSecureCookie: $scope.enabledSecureCookie || true,
                                 redirectLink: $scope.redirectLink,
                                 prefix: $scope.prefix,
                                 origin: $scope.origin

--- a/plugins/pencilblue/templates/angular/admin/sites/site_form.html
+++ b/plugins/pencilblue/templates/angular/admin/sites/site_form.html
@@ -24,7 +24,7 @@
                                 selectedLocales: $scope.selectedLocales,
                                 defaultLocale: $scope.defaultLocale,
                                 useCustomRedirect: $scope.useCustomRedirect || true,
-                                enabledSecureCookie: $scope.enabledSecureCookie || true,
+                                disableSecureCookie: $scope.disableSecureCookie || true,
                                 redirectLink: $scope.redirectLink,
                                 prefix: $scope.prefix,
                                 origin: $scope.origin


### PR DESCRIPTION
Added logic for setting "set-cookies" to be secure in pencilblue application on the basis of the **Secure Cookies** option selected(**true/false**) through admin panel. 

**Note:** Some changes of this PR is related with below PR:
           https://github.com/cbdr/CMSPencilblue/pull/2143 


@pencilblue/owners
