### PR TITLE
fix redirection issue

### DIFF
--- a/include/http/middleware/system.js
+++ b/include/http/middleware/system.js
@@ -19,7 +19,7 @@ module.exports = pb => ({
         const siteObj = pb.RequestHandler.sites[req.handler.hostname];
 
         if (siteObj && siteObj.prefix) {
-            req.url = req.url.replace(new RegExp(`^\/${siteObj.prefix}`), '');
+            req.url = req.url.replace(new RegExp(`^\/${siteObj.prefix}`), '') || '/';
             req.handler.url = url.parse(req.url, true);
         }
     },


### PR DESCRIPTION
This issue is to solve the prefix issue, currently we will remove the prefix to render the page content. 

If the request URL is: `/it-jobs` it should be replaced to be `/` instead of `empty `

It is to solve the issue of redirection page:
Currently, `http://premium.lvh.me:8080/it-jobs` will not have any redirection. 

### How to verify this feature?
- Add the settings in admin panel.
![image](https://user-images.githubusercontent.com/5660841/58230557-3cffa080-7d67-11e9-98b0-ac7e3f454612.png)
- You will see the redirection: `http://premium.lvh.me:8080/it-jobs` will be redirected to be `http://premium.lvh.me:8080/it-jobs/search` with this changes. 