### PR TITLE
rediret to profile view when logged in already

### DIFF
--- a/plugins/pencilblue/controllers/actions/salesforce/login.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login.js
@@ -19,6 +19,9 @@ module.exports = function LoginSFSSOControllerModule(pb) {
         async salesforceSSO(cb) {
             const salesforceStrategyService = new SalesforceStrategyService();
             const options = await salesforceStrategyService.getSalesforceLoginSettings(this.req);
+            if(options.url.indexOf('profile/view') !== -1){
+                return this.redirect(options.url,cb);
+            }
             if (this.query.state) {
                 try {
                     let state = JSON.parse(this.query.state);

--- a/plugins/pencilblue/controllers/actions/salesforce/login.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login.js
@@ -13,15 +13,17 @@ module.exports = function LoginSFSSOControllerModule(pb) {
     class LoginSFSSOController extends pb.BaseController {
         render(cb) {
             this.sanitizeObject(this.body);
-            this.salesforceSSO(cb);
+            if(this.req.session && this.req.session.authentication && this.req.session.authentication.user &&
+                this.req.session.authentication.user.external_user_id){
+                this.redirect (`http://${this.req.headers.host}/profile/view`,cb);
+            }else{
+                this.salesforceSSO(cb);
+            }
         }
 
         async salesforceSSO(cb) {
             const salesforceStrategyService = new SalesforceStrategyService();
             const options = await salesforceStrategyService.getSalesforceLoginSettings(this.req);
-            if(options.url.indexOf('profile/view') !== -1){
-                return this.redirect(options.url,cb);
-            }
             if (this.query.state) {
                 try {
                     let state = JSON.parse(this.query.state);

--- a/plugins/pencilblue/controllers/actions/salesforce/login.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login.js
@@ -15,7 +15,7 @@ module.exports = function LoginSFSSOControllerModule(pb) {
             this.sanitizeObject(this.body);
             if(this.req.session && this.req.session.authentication && this.req.session.authentication.user &&
                 this.req.session.authentication.user.external_user_id){
-                this.redirect (`https://${this.req.headers.host}/profile/view`,cb);
+                this.redirect (`/profile/view`,cb);
             }else{
                 this.salesforceSSO(cb);
             }

--- a/plugins/pencilblue/controllers/actions/salesforce/login.js
+++ b/plugins/pencilblue/controllers/actions/salesforce/login.js
@@ -15,7 +15,7 @@ module.exports = function LoginSFSSOControllerModule(pb) {
             this.sanitizeObject(this.body);
             if(this.req.session && this.req.session.authentication && this.req.session.authentication.user &&
                 this.req.session.authentication.user.external_user_id){
-                this.redirect (`http://${this.req.headers.host}/profile/view`,cb);
+                this.redirect (`https://${this.req.headers.host}/profile/view`,cb);
             }else{
                 this.salesforceSSO(cb);
             }

--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -74,9 +74,6 @@ module.exports = function(pb) {
 
         async getSalesforceLoginSettings(req) {
             try {
-                if(req.session && req.session.authentication && req.session.authentication.user && req.session.authentication.user.jobSeekerProfileId){
-                    return {url:`http://${req.headers.host}/profile/view`,method:'GET'}
-                }
                 const settings = await this.getSalesforceSettings(req);
                 const options = {
                     url: `${salesforceOAUTHAuthorizeService}?client_id=${settings.salesforce_client_id}&redirect_uri=${this.getCallBackURL(req)}&response_type=code&prompt=login`,

--- a/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
+++ b/plugins/pencilblue/services/salesforce/salesforce_strategy_service.js
@@ -74,6 +74,9 @@ module.exports = function(pb) {
 
         async getSalesforceLoginSettings(req) {
             try {
+                if(req.session && req.session.authentication && req.session.authentication.user && req.session.authentication.user.jobSeekerProfileId){
+                    return {url:`http://${req.headers.host}/profile/view`,method:'GET'}
+                }
                 const settings = await this.getSalesforceSettings(req);
                 const options = {
                     url: `${salesforceOAUTHAuthorizeService}?client_id=${settings.salesforce_client_id}&redirect_uri=${this.getCallBackURL(req)}&response_type=code&prompt=login`,


### PR DESCRIPTION
How to test:
Make sure you run in https mode.
1. change your pencileblue dependency in package.json to this branch
git@github.com:careerbuilder/pencilblue.git#enable-login-redirect
2. https://premium.lvh.me:8080/login/salesforce,Login in
3. Open another tab, go to https://premium.lvh.me:8080/login/salesforce, you will be redirect to https://premium.lvh.me:8080/profile/view page.
4. Clear the cookie, go to https://premium.lvh.me:8080/login/salesforce again, you will need to input credentials again.


