### PR TITLE
Bugfix/aceao 4399 search on ie

### DIFF
--- a/include/http/middleware/controller.js
+++ b/include/http/middleware/controller.js
@@ -71,23 +71,23 @@ module.exports = pb => ({
             // Inject the global value redirectHref in window
             content = content.replace(/<body[^>]*>/, function (match) {
                 return `${match}<script>
-                            const reg = new RegExp('^\/(?!${prefix})');
+                            var reg = new RegExp('^\/(?!${prefix})');
 
                             Object.defineProperty(window, 'redirectHref', {
-                                set(val) {
+                                'set': function (val) {
                                     if (reg.test(val)) {
                                         this.location.href = '/${prefix}' + val;
                                     } else {
                                         this.location.href = val;
                                     }
                                 },
-                                get() {
+                                'get': function () {
                                     return this.location.href;
                                 }
                             });
 
                             jQuery.fn.extend({
-                                attr: function( name, value ) {
+                                'attr': function ( name, value ) {
                                     if ((name === 'href' || name === 'src') && reg.test(value)) {
                                         value = '/${prefix}' + value;
                                     }

--- a/include/http/middleware/system.js
+++ b/include/http/middleware/system.js
@@ -19,7 +19,7 @@ module.exports = pb => ({
         const siteObj = pb.RequestHandler.sites[req.handler.hostname];
 
         if (siteObj && siteObj.prefix) {
-            req.url = req.url.replace(new RegExp(`^\/${siteObj.prefix}`), '') || '/';
+            req.url = req.url.replace(new RegExp(`^\/${siteObj.prefix}\/?`), '/');
             req.handler.url = url.parse(req.url, true);
         }
     },
@@ -49,7 +49,7 @@ module.exports = pb => ({
             let modulePath;
             try {
                 modulePath = require.resolve(match[1])
-            } catch(_) {
+            } catch (_) {
                 throw ErrorUtils.notFound()
             }
             await req.handler.servePublicContentAsync(modulePath);


### PR DESCRIPTION
What is the issues?
- When click search button on IE, the prefix is not added.
- `http://premium.lvh.me:8080/it-jobs?xxx=xxxx` will not redirect to `http://premium.lvh.me:8080/it-jobs/search?xxx=xxxx`

What is the changes?
- This issue is caused by some es6 JS do not supported well on IE. Need to remove all the es6.
- This is caused by the prefix support in our system. The current logic is if the URL contains prefix, it will be removed in the HTTP request. But we need to make sure there is `/` on the root domain. 

How to verify the changes?
- Click search button on IE. If there is no IE on your local machine, you can tested by coping t he related JS code in to staging site.
- Make sure the redirection happens on:
  - http://premium.lvh.me:8080/it-jobs?xxx=xxxx
  - http://premium.lvh.me:8080/it-jobs/?xxx=xxxx
  - http://premium.lvh.me:8080/it-jobs/
  - http://premium.lvh.me:8080/it-jobs
