### PR TITLE
fix ie issue with attr changes

### DIFF
--- a/include/http/middleware/controller.js
+++ b/include/http/middleware/controller.js
@@ -93,6 +93,13 @@ module.exports = pb => ({
                                     }
 
                                     return jQuery.access( this, jQuery.attr, name, value, arguments.length > 1 );
+                            　　},
+                                'prop': function ( name, value ) {
+                                    if ((name === 'href' || name === 'src') && reg.test(value)) {
+                                        value = '/${prefix}' + value;
+                                    }
+
+                                    return jQuery.access( this, jQuery.attr, name, value, arguments.length > 1 );
                             　　}
                             });
                         </script>`;


### PR DESCRIPTION
This PR is related with: https://github.com/careerbuilder/pencilblue/pull/143

There is another issue about IE is, when changing attributes on IE, it will call both` jQuery.attr` and `jQuery.prop`. That's why the injection does not work for IE.