### PR TITLE
Bugfix/fix admin prefix issue

### DIFF
--- a/include/http/middleware/controller.js
+++ b/include/http/middleware/controller.js
@@ -46,7 +46,7 @@ module.exports = pb => ({
         let content = req.controllerResult.content;
         const contentType = req.controllerResult.content_type;
 
-        if (prefix && content && !/.*admin/.test(req.url) &&
+        if (prefix && content && !/^\/admin\//.test(req.url) &&
                 (contentType === 'text/html' || contentType === undefined) &&
                 ((typeof content) === 'string')) {
 


### PR DESCRIPTION
This is a small issue, so I did not create a new card. So I pushed this fix into 4399. It's a same issue related with the prefix. But it exists on both IE and chrome.

There are some jobs contains: `admin` will skip the prefix.
https://astoncarter.jobs.net/en-US/job/administrative-support-coordinator/J3P06N7201PWWLQ7S9T

### How to reproduce this issue on DEV?
- Just pick any job and change the job title to contains `admin`.
`http://premium.lvh.me:8080/en-US/job/admin-nurse-contract-pcu/J3T3YZ6KV0RX48MBKDP`
- And verify the relative links, and you will see it does not contains the prefix.
![image](https://user-images.githubusercontent.com/5660841/59585172-7206d500-9112-11e9-87ed-e726e37bf41f.png)

### How to verify the changes?
Rebase the latest changes in `pencilblue`. And make sure with the same link, you can see the prefix.