### PR TITLE
Bugfix/aceao 4776 secure cookie

### DIFF
--- a/include/http/request_handler.js
+++ b/include/http/request_handler.js
@@ -356,7 +356,8 @@ module.exports = function RequestHandlerModule(pb) {
                 }
 
                 this.resp.setHeader('content-type', contentType);
-                let disableSecureCookie = this.req && this.req.siteObj && this.req.siteObj.disableSecureCookie;
+                const isDev = process && process.env && process.env.NODE_ENV === 'development';
+                const disableSecureCookie = (this.req && this.req.siteObj && this.req.siteObj.disableSecureCookie) || isDev;
                 const cookies = this.resp.getHeader('set-cookie');
                 if (!disableSecureCookie && cookies) {
                     cookies.forEach((cookie, index) => {


### PR DESCRIPTION
### What is the issue?
The secure check will make the cookie not work on http. 
One example is:
- Clear cookies on the page, like: http://sa.lvh.me:8080/
- Refresh the page, you will not see the **cms_tn_session_id**.

### How to fix?
I have added a DEV check to make the cookie work on DEV.

### How to verify?
- Clear cookies on the page, like: http://sa.lvh.me:8080/
- Refresh the page, you will see the **cms_tn_session_id** has been added.