### PR TITLE
Add function to process the url using the site origin value. ACEAO-6118

### DIFF
--- a/controllers/base_controller.js
+++ b/controllers/base_controller.js
@@ -329,7 +329,6 @@ module.exports = function BaseControllerModule(pb) {
                 return;
             }
             var relationship = self.ls.language === locale ? 'canonical' : 'alternate';
-
             var urlOpts = {
                 hostname: self.hostname,
                 locale: undefined
@@ -344,10 +343,19 @@ module.exports = function BaseControllerModule(pb) {
                 urlOpts.locale = locale;
             }
             var url = pb.UrlService.createSystemUrl(path, urlOpts);
+            url = self.processUrlWithSiteOrigin(url);
             val += '<link rel="' + relationship + '" hreflang="' + locale + '" href="' + url + '" />\n';
         });
         cb(null, new pb.TemplateValue(val, false));
     };
+
+    BaseController.prototype.processUrlWithSiteOrigin = function(url){
+        if (this.siteObj.origin && this.siteObj.prefix) {
+            var origin = this.siteObj.origin + "/" + this.siteObj.prefix;
+            url = url.replace(/[a-zA-Z]*.jobs.net/g, origin);
+        }
+        return url;
+    }
 
     /**
      * Retrieves a context object that contains the necessary information for

--- a/controllers/base_controller.js
+++ b/controllers/base_controller.js
@@ -351,8 +351,9 @@ module.exports = function BaseControllerModule(pb) {
 
     BaseController.prototype.processUrlWithSiteOrigin = function(url){
         if (this.siteObj.origin && this.siteObj.prefix) {
-            var origin = this.siteObj.origin + "/" + this.siteObj.prefix;
-            url = url.replace(/[a-zA-Z]*.jobs.net/g, origin);
+            var protocol = this.hostname.split(":")[0];
+            var origin = protocol + "://" + this.siteObj.origin + "/" + this.siteObj.prefix;
+            url = url.replace(this.hostname, origin);
         }
         return url;
     }


### PR DESCRIPTION
This is to fix the "bug" Allegis reported in card ACEAO-6118

steps to test: 
1. Pull the branch 
2. Link CMSPencilblue to your local copy of pencilblue 
3. Start CMSPencilblue
4. Go to the admin panel and select the site you're going to test and add Site Origin and a Prefix 
5. Go to the JDP of any job and with the console open, look for the canonical or alternate tags and make sure the links show the site origin + prefix instead of the default hostname. 